### PR TITLE
Easy to use, do to enforce library clients to override manifest

### DIFF
--- a/permission_manager/src/main/AndroidManifest.xml
+++ b/permission_manager/src/main/AndroidManifest.xml
@@ -1,10 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-
     package="com.karan.churi.PermissionManager">
 
-    <application android:allowBackup="true" android:label="@string/app_name"
-        android:supportsRtl="true">
-
-    </application>
+    <application/>
 
 </manifest>


### PR DESCRIPTION
Without these changes client applications have next build error:
"Attribute application@allowBackup value=(false) from AndroidManifest.xml:24:9-36
	is also present at [com.github.karanchuri:PermissionManager:0.1.0] AndroidManifest.xml:12:9-35 value=(true).
	Suggestion: add 'tools:replace="android:allowBackup"' to <application> element at AndroidManifest.xml:22:5-426:19 to override."